### PR TITLE
Minio support + Stageout refactoring

### DIFF
--- a/zoo-project-dru/Chart.yaml
+++ b/zoo-project-dru/Chart.yaml
@@ -38,3 +38,7 @@ dependencies:
     version: "17.6.0"
     repository: https://charts.bitnami.com/bitnami
 
+  - name: minio
+    version: 12.8.4
+    repository: https://charts.bitnami.com/bitnami
+    condition: minio.enabled

--- a/zoo-project-dru/files/cwlwrapper-assets/stagein.yaml
+++ b/zoo-project-dru/files/cwlwrapper-assets/stagein.yaml
@@ -20,31 +20,23 @@ arguments:
 - ./
 - valueFrom: ${ return inputs.input.split("#")[0]; }
 inputs:
-  ADES_STAGEIN_AWS_SERVICEURL:
+  STAGEIN_AWS_SERVICEURL:
     type: string?
-  ADES_STAGEIN_AWS_REGION:
+  STAGEIN_AWS_REGION:
     type: string?
-  ADES_STAGEIN_AWS_ACCESS_KEY_ID:
+  STAGEIN_AWS_ACCESS_KEY_ID:
     type: string?
-  ADES_STAGEIN_AWS_SECRET_ACCESS_KEY:
+  STAGEIN_AWS_SECRET_ACCESS_KEY:
     type: string?
 outputs: {}
 requirements:
   EnvVarRequirement:
     envDef:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      # AWS__Profile: $(inputs.aws_profile)
-      # AWS__ProfilesLocation: $(inputs.aws_profiles_location.path)
-      AWS__ServiceURL: $(inputs.ADES_STAGEIN_AWS_SERVICEURL)
-      AWS__Region: $(inputs.ADES_STAGEIN_AWS_REGION)
-      AWS__AuthenticationRegion: $(inputs.ADES_STAGEIN_AWS_REGION)
-      AWS_ACCESS_KEY_ID: $(inputs.ADES_STAGEIN_AWS_ACCESS_KEY_ID)
-      AWS_SECRET_ACCESS_KEY: $(inputs.ADES_STAGEIN_AWS_SECRET_ACCESS_KEY)
-      "Credentials__StacCatalog__AuthType" : "Basic"
-      "Credentials__StacCatalog__UriPrefix" : "https://supervisor.{{ .Values.global.ingress.hostDomain }}"
-      "Credentials__StacCatalog__Username" : "stars"
-      "Credentials__StacCatalog__Password" : "89126578214hr87fh8g2389"
-      # STARS_URL_FIND: "https?://supervisor.charter.uat.esaportal.eu/catalog"
-      # STARS_URL_REPLACE: "http://acceptance-supervisor-catalog-stac.cpe/catalog"
+      AWS__ServiceURL: $(inputs.STAGEIN_AWS_SERVICEURL)
+      AWS__Region: $(inputs.STAGEIN_AWS_REGION)
+      AWS__AuthenticationRegion: $(inputs.STAGEIN_AWS_REGION)
+      AWS_ACCESS_KEY_ID: $(inputs.STAGEIN_AWS_ACCESS_KEY_ID)
+      AWS_SECRET_ACCESS_KEY: $(inputs.STAGEIN_AWS_SECRET_ACCESS_KEY)
   ResourceRequirement: {}
   InlineJavascriptRequirement: {}

--- a/zoo-project-dru/files/cwlwrapper-assets/stageout.yaml
+++ b/zoo-project-dru/files/cwlwrapper-assets/stageout.yaml
@@ -12,7 +12,7 @@ arguments:
   - -r
   - '4'
   - -o
-  - $( inputs.ADES_STAGEOUT_OUTPUT + "/" + inputs.process )
+  - $( inputs.STAGEOUT_OUTPUT + "/" + inputs.process )
   - -res
   - $( inputs.process + ".res" )
   - valueFrom: |
@@ -29,37 +29,35 @@ arguments:
           return args;
       }
 inputs:
-  ADES_STAGEOUT_AWS_PROFILE:
+  AWS_PROFILE:
     type: string?
-  ADES_STAGEOUT_AWS_SERVICEURL:
+  AWS_SERVICE_URL:
     type: string?
-  ADES_STAGEOUT_AWS_ACCESS_KEY_ID:
+  AWS_ACCESS_KEY_ID:
     type: string?
-  ADES_STAGEOUT_AWS_SECRET_ACCESS_KEY:
+  AWS_SECRET_ACCESS_KEY:
     type: string?
   aws_profiles_location:
     type: File?
-  ADES_STAGEOUT_OUTPUT:
+  STAGEOUT_OUTPUT:
     type: string?
-  ADES_STAGEOUT_AWS_REGION:
+  AWS_REGION:
     type: string?
   process:
     type: string?
 outputs:
   s3_catalog_output:
     outputBinding:
-      outputEval: ${ return inputs.ADES_STAGEOUT_OUTPUT + "/" + inputs.process + "/catalog.json"; }
+      outputEval: ${ return inputs.STAGEOUT_OUTPUT + "/" + inputs.process + "/catalog.json"; }
     type: string
 requirements:
   InlineJavascriptRequirement: {}
   EnvVarRequirement:
     envDef:
       PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      # AWS__Profile: $(inputs.ADES_STAGEOUT_AWS_PROFILE)
-      # AWS__ProfilesLocation: $(inputs.aws_profiles_location.path)
-      AWS__ServiceURL: $(inputs.ADES_STAGEOUT_AWS_SERVICEURL)
-      AWS__Region: $(inputs.ADES_STAGEOUT_AWS_REGION)
-      AWS__AuthenticationRegion: $(inputs.ADES_STAGEOUT_AWS_REGION)
-      AWS_ACCESS_KEY_ID: $(inputs.ADES_STAGEOUT_AWS_ACCESS_KEY_ID)
-      AWS_SECRET_ACCESS_KEY: $(inputs.ADES_STAGEOUT_AWS_SECRET_ACCESS_KEY)
+      AWS__ServiceURL: $(inputs.AWS_SERVICE_URL)
+      AWS__Region: $(inputs.AWS_REGION)
+      AWS__AuthenticationRegion: $(inputs.AWS_REGION)
+      AWS_ACCESS_KEY_ID: $(inputs.AWS_ACCESS_KEY_ID)
+      AWS_SECRET_ACCESS_KEY: $(inputs.AWS_SECRET_ACCESS_KEY)
   ResourceRequirement: {}

--- a/zoo-project-dru/values.yaml
+++ b/zoo-project-dru/values.yaml
@@ -172,3 +172,6 @@ persistence:
 
 cookiecutter:
   templateUrl: https://github.com/EOEPCA/proc-service-template.git
+
+minio:
+  enabled: false

--- a/zoo-project-dru/values.yaml
+++ b/zoo-project-dru/values.yaml
@@ -123,11 +123,16 @@ workflow:
 
   inputs:
     APP: zoo-project-dru
-    AWS_REGION: fr-par
-    AWS_ACCESS_KEY_ID: my_access_key
-    AWS_SECRET_ACCESS_KEY: my_secret_access_key
-    AWS_SERVICE_URL: https://s3endpoint.cloud
-    ADES_STAGEOUT_OUTPUT: s3://eoepca-ades
+    STAGEIN_AWS_REGION: RegionOne
+    STAGEIN_AWS_ACCESS_KEY_ID: minio-admin
+    STAGEIN_AWS_SECRET_ACCESS_KEY: minio-secret-password
+    STAGEIN_AWS_SERVICE_URL: http://zoo-project-dru-minio.zp.svc.cluster.local:9000
+    STAGEOUT_AWS_REGION: RegionOne
+    STAGEOUT_AWS_ACCESS_KEY_ID: minio-admin
+    STAGEOUT_AWS_SECRET_ACCESS_KEY: minio-secret-password
+    STAGEOUT_AWS_SERVICE_URL: http://zoo-project-dru-minio.zp.svc.cluster.local:9000
+    STAGEOUT_OUTPUT: 3://processingresults
+
 
 
 postgresql:

--- a/zoo-project-dru/values_minikube.yaml
+++ b/zoo-project-dru/values_minikube.yaml
@@ -2,11 +2,11 @@ workflow:
   storageClass: standard
   inputs:
     APP: zoo-project-dru
-    AWS_REGION: RegionOne
-    AWS_ACCESS_KEY_ID: minio-admin
-    AWS_SECRET_ACCESS_KEY: minio-secret-password
-    AWS_SERVICE_URL: http://zoo-project-dru-minio.zp.svc.cluster.local:9000
-    ADES_STAGEOUT_OUTPUT: 3://processingresults
+    STAGEOUT_AWS_REGION: RegionOne
+    STAGEOUT_AWS_ACCESS_KEY_ID: minio-admin
+    STAGEOUT_AWS_SECRET_ACCESS_KEY: minio-secret-password
+    STAGEOUT_AWS_SERVICE_URL: http://zoo-project-dru-minio.zp.svc.cluster.local:9000
+    STAGEOUT_OUTPUT: 3://processingresults
 
 minio:
   # minio chart value parameters description can be found here:

--- a/zoo-project-dru/values_minikube.yaml
+++ b/zoo-project-dru/values_minikube.yaml
@@ -3,7 +3,23 @@ workflow:
   inputs:
     APP: zoo-project-dru
     AWS_REGION: RegionOne
-    AWS_ACCESS_KEY_ID: minio
-    AWS_SECRET_ACCESS_KEY: minio123
-    AWS_SERVICE_URL: http://my-minio-fs.minio.svc.cluster.local:9000
+    AWS_ACCESS_KEY_ID: minio-admin
+    AWS_SECRET_ACCESS_KEY: minio-secret-password
+    AWS_SERVICE_URL: http://zoo-project-dru-minio.zp.svc.cluster.local:9000
     ADES_STAGEOUT_OUTPUT: 3://processingresults
+
+minio:
+  # minio chart value parameters description can be found here:
+  # https://github.com/bitnami/charts/tree/main/bitnami/minio
+  enabled: true
+  auth:
+    rootUser: minio-admin
+    rootPassword: minio-secret-password
+    # to access the dashboard from browser run the following port-forward command:
+    # kubectl port-forward svc/zoo-project-dru-minio 9001:9001 -n zp
+  persistence:
+    enabled: true
+    storageClass: standard
+    size: 2Gi
+    accessMode: ReadWriteOnce
+  defaultBuckets: "processingresults"


### PR DESCRIPTION
### Minio Support for Effortless Project Kickstart

With the aim of simplifying the project's onboarding procedure, this pull request introduces seamless integration of Minio, an open-source object storage solution. Please note that this feature primarily serves as a convenient option for testing and development purposes. In production environments, we strongly recommend utilizing a different S3-compatible object storage solution.

To enable Minio storage within your deployment, you can effortlessly configure it by updating the values in the Helm chart as follows:

```yaml
minio:
  enabled: true
  auth:
    rootUser: minio-admin
    rootPassword: minio-secret-password
    # To access the dashboard from your browser, execute the following port-forward command:
    # kubectl port-forward svc/zoo-project-dru-minio 9001:9001 -n zp
  persistence:
    enabled: true
    storageClass: standard
    size: 2Gi
    accessMode: ReadWriteOnce
  defaultBuckets: "processingresults"
```
For more details on Minio chart value parameters and their descriptions, please refer to the [official documentation](https://github.com/bitnami/charts/tree/main/bitnami/minio).

With this enhancement, we aim to make the setup process more user-friendly and expedite your journey with our project. 

###  Stageout refactoring

The term _ADES_ has been removed from the stageout cwl and inputs.