### PR TITLE
Cookiecutter Template Branch Property

### DIFF
--- a/zoo-project-dru/Chart.yaml
+++ b/zoo-project-dru/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/zoo-project-dru/files/zoo-kernel/main.cfg.tpl
+++ b/zoo-project-dru/files/zoo-kernel/main.cfg.tpl
@@ -63,6 +63,7 @@ hosts=*
 configurationFile={{ .Values.persistence.tmpPath }}/cookiecutter_config.yaml
 templatesPath={{ .Values.persistence.tmpPath }}/cookiecutter-templates
 templateUrl={{ .Values.cookiecutter.templateUrl }}
+templateBranch={{ .Values.cookiecutter.templateBranch }}
 
 
 [servicesNamespace]

--- a/zoo-project-dru/values_minikube.yaml
+++ b/zoo-project-dru/values_minikube.yaml
@@ -23,3 +23,7 @@ minio:
     size: 2Gi
     accessMode: ReadWriteOnce
   defaultBuckets: "processingresults"
+  
+cookiecutter:
+  templateUrl: https://github.com/EOEPCA/proc-service-template.git
+  templateBranch: zoo-project-dru


### PR DESCRIPTION
# Cookiecutter Service Template Branch

## Description

This pull request enhances the `zoo-project-dru` Helm chart values by allowing the specification of a Git branch when setting the `cookiecutter` template URL. This addition offers flexibility in choosing the branch from which to clone the cookiecutter template. If no branch is specified, it will default to 'master'.
 For instance:

```yaml
cookiecutter:
  templateUrl: https://github.com/EOEPCA/proc-service-template.git
  templateBranch: zoo-project-dru
```

## Testing

### Testing Plan

To verify this feature:

1. In `zoo-project-dru/values_minikube.yaml` of the `zoo-project-dru` Helm chart, set the tag of the new Docker image:

```yaml
zoofpm:
  image:
    repository: zooproject/zoo-project
    pullPolicy: IfNotPresent
    tag: template-branch-feature

zookernel:
  image:
    repository: zooproject/zoo-project
    pullPolicy: IfNotPresent
    tag: template-branch-feature
```

3. Update or add the `cookiecutter` section in `zoo-project-dru/values_minikube.yaml` by specifying the branch:

```yaml
cookiecutter:
  templateUrl: https://github.com/EOEPCA/proc-service-template.git
  templateBranch: zoo-project-dru
```

4. Deploy the `zoo-project-dru` Helm chart:

```shell
helm upgrade --install zoo-project-dru zoo-project-dru/ -f zoo-project-dru/values_minikube.yaml -n zp --create-namespace
```

5. Deploy a service.

6. Access the `zoofpm` pod, navigate to the deployed services folder, and confirm that the service deployed in the previous step was generated using the cookiecutter template from the 'zoo-project-dru' branch.

