### PR TITLE
host update in oas.cfg and main.cfg

### DIFF
--- a/zoo-project-dru/files/zoo-kernel/main.cfg.tpl
+++ b/zoo-project-dru/files/zoo-kernel/main.cfg.tpl
@@ -5,7 +5,13 @@ serverAddress = http://127.0.0.1
 language = en-US
 lang = fr-FR,en-CA,en-US
 tmpPath={{ .Values.persistence.tmpPath }}
+{{- if .Values.ingress.enabled }}
+{{- with (first .Values.ingress.hosts) }}
+tmpUrl = http://{{ .host }}/temp/
+{{- end }}
+{{- else }}
 tmpUrl = http://localhost/temp/
+{{- end }}
 dataPath = /usr/com/zoo-project
 cacheDir ={{ .Values.persistence.tmpPath }}
 templatesPath = /var/www/

--- a/zoo-project-dru/files/zoo-kernel/oas.cfg
+++ b/zoo-project-dru/files/zoo-kernel/oas.cfg
@@ -1,7 +1,14 @@
 [openapi]
 use_content=false
+{{- if .Values.ingress.enabled }}
+{{- with (first .Values.ingress.hosts) }}
+rootUrl=https://{{ .host }}/ogc-api
+rootHost=https://{{ .host }}
+{{- end }}
+{{- else }}
 rootUrl=http://localhost/ogc-api
 rootHost=http://localhost:8080
+{{- end }}
 rootPath=ogc-api
 links=/,/api,/conformance,/processes,/jobs
 paths=/root,/api,/conformance,/processes,/processes/{processID},/processes/snuggs/execution,/processes/{processID}/execution,/jobs,/jobs/{jobID},/jobs/{jobID}/results
@@ -100,7 +107,14 @@ rel=service-doc
 type=text/html
 
 [api.html]
+{{- if .Values.ingress.enabled }}
+{{- with (first .Values.ingress.hosts) }}
+href=https://{{ .host }}/swagger-ui/oapip/
+{{- end }}
+{{- else }}
 href=http://localhost:8080/swagger-ui/oapip/
+{{- end }}
+
 
 [api]
 method=get


### PR DESCRIPTION
This pull request proposes an automation enhancement that will update specific properties whenever the ingress is enabled. The changes will be made in the configuration files as follows:

In the '**main.cfg**' file:

-  tmpUrl

In the '**oas.cfg**' file:

- rootUrl
- rootHost
- [api.html]href

