### PR TITLE
Align test-connection pod with the correct service name

### DIFF
--- a/zoo-project-dru/templates/tests/test-connection.yaml
+++ b/zoo-project-dru/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "zoo-project-dru.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ .Release.Name }}-service:{{ .Values.service.port }}']
   restartPolicy: Never


### PR DESCRIPTION
The test-connection was failing after clean deployment. This appears to fix the problem.