### PR TITLE
Allow additional customisation through helm values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-zoo-project-dru/Chart.lock
-zoo-project-dru/charts/minio-12.8.4.tgz
-zoo-project-dru/charts/postgresql-12.1.9.tgz
-zoo-project-dru/charts/rabbitmq-11.5.0.tgz
-zoo-project-dru/charts/redis-17.6.0.tgz
+zoo-project-dru/charts/*.tgz

--- a/zoo-project-dru/files/zoo-project/main.cfg
+++ b/zoo-project-dru/files/zoo-project/main.cfg
@@ -87,9 +87,7 @@ has_jwt_service=true
 sections_list=eoepca,auth_env,additional_parameters,pod_env_vars,pod_node_selector
 required_files=
 
-[eoepca]
-domain=demo.eoepca.org
-workspace_prefix=demo-user
+{{ .Values.customConfig.main | nindent 2 }}
 
 [headers]
 X-Powered-By=ZOO-Project-DRU

--- a/zoo-project-dru/templates/cm-cwlwrapper-assets.yaml
+++ b/zoo-project-dru/templates/cm-cwlwrapper-assets.yaml
@@ -3,4 +3,12 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-cwlwrapper-config
 data:
-  {{- (.Files.Glob "files/cwlwrapper-assets/*").AsConfig | nindent 2 }}
+{{- $globPattern := "files/cwlwrapper-assets/*" }}
+{{- $values := .Values }}
+{{- $files := .Files }}
+{{- range $path, $_ := $files.Glob $globPattern }}
+  {{- $filename := $path | base }}
+  {{- $fileOverride := get $values.files.cwlwrapperAssets $filename }}
+  {{ $filename }}: |-
+    {{- $fileOverride | default ($files.Get $path) | nindent 4 }}
+{{- end }}

--- a/zoo-project-dru/values.yaml
+++ b/zoo-project-dru/values.yaml
@@ -187,3 +187,12 @@ filter_out:
   enabled: true
   path: /usr/lib/cgi-bin
   service: securityOut
+
+# Value overrides for the file assets included within the chart template.
+files:
+  # Directory `files/cwlwrapper-assets` - assets for ConfigMap `XXX-cwlwrapper-config`
+  cwlwrapperAssets: {}
+    # main.yaml: ""
+    # rules.yaml: ""
+    # stagein.yaml: ""
+    # stageout.yaml: ""

--- a/zoo-project-dru/values.yaml
+++ b/zoo-project-dru/values.yaml
@@ -196,3 +196,20 @@ files:
     # rules.yaml: ""
     # stagein.yaml: ""
     # stageout.yaml: ""
+
+# Provide custom contribution to the zoo configuration files.
+customConfig:
+  # file main.cfg
+  main: ""
+#
+# Example - passing through custom config that can be accessed directly in a
+# cookiecutter template that is provided as a deployment customisation.
+# The cookiecutter must be coded to expect these passed-thru parameters by name,
+# i.e. under the keys ["myCustomConfig"]["domain"], etc.
+#
+# ---
+# customConfig:
+#   main: |-
+#     [myCustomConfig]
+#     domain=mycluster.myplatform
+#     workspace_prefix=ws


### PR DESCRIPTION
Updates to make it possible to apply deployment time customisations (through values) that are needed for relocatable eoepca deployments.

Includes...
* The ability to override the cwlwrapper file assets through helm values
* The ability to add custom custom configuration to main.cfg - removing hard-coded eoepca reference

See the updated values file for additional comments/examples.

For example, this allows to specify the config values expected by the eoepca cookie-cutter template...
```
    customConfig:
      main: |-
        [eoepca]
        domain=c23121301.guide.eoepca.org
        workspace_prefix=ws
```