### PR TITLE
Update test-connection pod to wait for zoo service to start

### DIFF
--- a/zoo-project-dru/templates/tests/test-connection.yaml
+++ b/zoo-project-dru/templates/tests/test-connection.yaml
@@ -10,6 +10,9 @@ spec:
   containers:
     - name: wget
       image: busybox
-      command: ['wget']
-      args: ['{{ .Release.Name }}-service:{{ .Values.service.port }}']
+      command: ["sh"]
+      args: [
+        "-c",
+        "let status=1; while test $status -ne 0; do wget -T 5 {{ .Release.Name }}-service:{{ .Values.service.port }}; let status=$?; sleep 5; done"
+      ]
   restartPolicy: Never


### PR DESCRIPTION
This was always failing since it makes the wget test before the service is ready.
Now the test connection keeps trying (`Running`) until the connection succeeds - at which point it `Completes`.