### PR TITLE
Add value `ingress.hosturl` for externally provided ingress

### DIFF
--- a/zoo-project-dru/Chart.lock
+++ b/zoo-project-dru/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.2.5
+- name: rabbitmq
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.5.4
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 17.6.0
+- name: minio
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.10.3
+digest: sha256:88e02cb4d1da2f84af02785ec39443ef9d09982cd123351914986fc9492f18ed
+generated: "2024-01-31T10:45:31.178477419Z"

--- a/zoo-project-dru/Chart.yaml
+++ b/zoo-project-dru/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/zoo-project-dru/README.md
+++ b/zoo-project-dru/README.md
@@ -171,11 +171,33 @@ In case you have enabled redis and disabled IAM, you can activate the websocketd
 | workflow.env                                             | Environmental variables for the processing pods       | {}                                          |
 
 
+### ingress
+
+Defines the ingress through which the `zoo-dru` service is exposed for access outside of the cluster.
+
+In addition, the values specified here are used to derive the service URL that `zoo-dru` uses to reference its own resources - for example, the URLs returned in API responses regarding the location of job status and processing results, etc. Accordingly, the service URL is deduced in the following order of priority...
+* `ingress.hosturl` (if specified)
+* `ingress.hosts.host[0]` if `ingress.enabled: true`
+* `http://localhost:8080` if all else fails
+
+| Name | Descriptoin | Value |
+|:-----|:------------|:------|
+| ingress.enabled | Enables creation of ingress resource for the `zoo-dru` service.<br>In the case that `enabled: false` is set, then other values (with the exception of `hosturl`) do not apply | `false` |
+| ingress.hosturl | (optional) The URL through which the `zoo-dru` service is externally exposed.<br>_See explanation in preamble above._ | _not specified_ |
+| ingress.className | Identifies the class of ingress controller that should satisfy the ingress request | "" |
+| ingress.annotations | Additional parameters that are passed as configuration to the ingress controller that satisfies the ingress.<br>_See documentation of specific ingress controller for details._  | {} |
+| ingress.hosts | Array of one or more host specifications that provide ingress rules | _see following items_ |
+| ingress.hosts[n].host | Hostname to match for the ingress rule | `chart-example.local` |
+| ingress.hosts[n].paths | Array of paths to match for the ingress rule | _see following items_ |
+| ingress.hosts[n].paths[m].path | Path to match for the ingress rule | `/` |
+| ingress.hosts[n].paths[m].pathType | Paths matching policy for the ingress rule | `ImplementationSpecific` |
+| ingress.tls | (optional) Array of zero or more specifications providing details of TLS certificate to be used for specific hostnames | []<br>_see following items_ |
+| ingress.tls[n].hosts | Array of hostnames to be associated with the TLS certificate | _not specified_ |
+| ingress.tls[n].secretName | Name of secret that holds the TLS certificate | _not specified_ |
+
+
 ### customConfig
 
 | Name                                                     | Description                        | Value                                                                 |
 |:---------------------------------------------------------|:-----------------------------------|:----------------------------------------------------------------------|
 | customConfig.main                                    | Optional sections to include in the main.cfg file.             | {}                                                              |
-
-
-

--- a/zoo-project-dru/files/zoo-project/htaccess
+++ b/zoo-project-dru/files/zoo-project/htaccess
@@ -1,3 +1,4 @@
+{{- $hosturl := include "zoo-project-dru.hosturl" . -}}
 RewriteEngine On
 SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 SetEnvIf Request_URI "^\/?(\w+)\/ogc-api(.*)" SERVICES_NAMESPACE=$1
@@ -5,13 +6,6 @@ RewriteRule ^\/?(\w+)\/ogc-api/(.*) /ogc-api/$2 [PT]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ogc-api/api.html$ /cgi-bin/zoo_loader.cgi?/api.html [L,QSA]
-{{- if .Values.ingress.enabled }}
-{{- with (first .Values.ingress.hosts) }}
-RewriteRule ^ogc-api/index.html$ /cgi-bin/zoo_loader.cgi?service=WPS&service=WPS&request=Execute&version=1.0.0&Identifier=display&RawDataOutput=Result&DataInputs=tmpl=@xlink:href=https://{{ .host }}/ogc-api/ [L,QSA]
-RewriteRule ^ogc-api(.*).html$ /cgi-bin/zoo_loader.cgi?service=WPS&service=WPS&request=Execute&version=1.0.0&Identifier=display&RawDataOutput=Result&DataInputs=tmpl=@xlink:href=https://{{ .host }}/ogc-api$1 [L,QSA]
-{{- end }}
-{{- else }}
-RewriteRule ^ogc-api/index.html$ /cgi-bin/zoo_loader.cgi?service=WPS&service=WPS&request=Execute&version=1.0.0&Identifier=display&RawDataOutput=Result&DataInputs=tmpl=@xlink:href=http://localhost/ogc-api/ [L,QSA]
-RewriteRule ^ogc-api(.*).html$ /cgi-bin/zoo_loader.cgi?service=WPS&service=WPS&request=Execute&version=1.0.0&Identifier=display&RawDataOutput=Result&DataInputs=tmpl=@xlink:href=http://localhost/ogc-api$1 [L,QSA]
-{{- end }}
+RewriteRule ^ogc-api/index.html$ /cgi-bin/zoo_loader.cgi?service=WPS&service=WPS&request=Execute&version=1.0.0&Identifier=display&RawDataOutput=Result&DataInputs=tmpl=@xlink:href={{ $hosturl }}/ogc-api/ [L,QSA]
+RewriteRule ^ogc-api(.*).html$ /cgi-bin/zoo_loader.cgi?service=WPS&service=WPS&request=Execute&version=1.0.0&Identifier=display&RawDataOutput=Result&DataInputs=tmpl=@xlink:href={{ $hosturl }}/ogc-api$1 [L,QSA]
 RewriteRule ^ogc-api(.*)$ /cgi-bin/zoo_loader.cgi?$1 [L,QSA]

--- a/zoo-project-dru/files/zoo-project/main.cfg
+++ b/zoo-project-dru/files/zoo-project/main.cfg
@@ -1,7 +1,8 @@
-{{- $customPrefixes := "" }}
-{{- range $k, $_ := .Values.customConfig.main }}
-{{- $customPrefixes = (print $customPrefixes "," $k) }}
-{{- end }}
+{{- $hosturl := include "zoo-project-dru.hosturl" . -}}
+{{- $customPrefixes := "" -}}
+{{- range $k, $_ := .Values.customConfig.main -}}
+{{- $customPrefixes = (print $customPrefixes "," $k) -}}
+{{- end -}}
 [main]
 encoding = utf-8
 version = 1.0.0
@@ -9,15 +10,8 @@ serverAddress = http://127.0.0.1
 language = en-US
 lang = fr-FR,en-CA,en-US
 tmpPath={{ .Values.persistence.tmpPath }}
-{{- if .Values.ingress.enabled }}
-{{- with (first .Values.ingress.hosts) }}
-tmpUrl = https://{{ .host }}/temp/
-mapserverAddress = https://{{ .host }}/cgi-bin/mapserv
-{{- end }}
-{{- else }}
-tmpUrl = http://localhost:8080/temp/
-mapserverAddress = http://localhost:8080/cgi-bin/mapserv
-{{- end }}
+tmpUrl = {{ $hosturl }}/temp/
+mapserverAddress = {{ $hosturl }}/cgi-bin/mapserv
 dataPath = /usr/com/zoo-project
 cacheDir ={{ .Values.persistence.tmpPath }}
 templatesPath = /var/www/
@@ -92,8 +86,8 @@ sections_list={{ print "auth_env,additional_parameters,pod_env_vars,pod_node_sel
 required_files=
 
 {{- range $k, $v := .Values.customConfig.main }}
-{{- print "\n[" $k "]" | nindent 2 }}
-{{- $v | nindent 2 }}
+{{ print "\n[" $k "]" }}
+{{ $v }}
 {{- end }}
 
 [headers]

--- a/zoo-project-dru/files/zoo-project/oas.cfg
+++ b/zoo-project-dru/files/zoo-project/oas.cfg
@@ -1,14 +1,9 @@
+{{- $hosturl := include "zoo-project-dru.hosturl" . -}}
+{{- $hosturlws := include "zoo-project-dru.hosturlws" . -}}
 [openapi]
 use_content=false
-{{- if .Values.ingress.enabled }}
-{{- with (first .Values.ingress.hosts) }}
-rootUrl=https://{{ .host }}/ogc-api
-rootHost=https://{{ .host }}
-{{- end }}
-{{- else }}
-rootUrl=http://localhost:8080/ogc-api
-rootHost=http://localhost:8080
-{{- end }}
+rootUrl={{ $hosturl }}/ogc-api
+rootHost={{ $hosturl }}
 rootPath=ogc-api
 links=/,/api,/conformance,/processes,/jobs
 paths=/root,/conformance,/api,/processes,/processes/water-bodies,/processes/{processID},/processes/water-bodies/execution,/processes/{processID}/execution,/jobs,/jobs/{jobID},/jobs/{jobID}/results
@@ -19,24 +14,12 @@ license_name=OGC license
 license_url=https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/LICENSE
 full_html_support=false
 partial_html_support=false
-{{- if .Values.ingress.enabled }}
-{{- with (first .Values.ingress.hosts) }}
-wsUrl=wss://{{ .host }}:8888/
-{{- end }}
-{{- else }}
-wsUrl=ws://localhost:8888/
-{{- end }}
+wsUrl={{ $hosturlws }}/
 publisherUrl=http://zookernel/cgi-bin/publish.py?jobid=
 link_href=http://zoo-project.org/dl/link.json
 tags=Browse the API,List - deploy - get detailed information about processes,Execute process - monitor job - access the result,Jobs management,Processes management,Other endpoints
 examplesPath=/var/www/html/examples/
-{{- if .Values.ingress.enabled }}
-{{- with (first .Values.ingress.hosts) }}
-examplesUrl=http://{{ .host }}/examples/
-{{- end }}
-{{- else }}
-examplesUrl=http://localhost:8080/examples/
-{{- end }}
+examplesUrl={{ $hosturl }}/examples/
 exceptionsUrl=http://www.opengis.net/def/rel/ogc/1.0/exception
 exceptionsUrl_1=http://www.opengis.net/def/exceptions/ogcapi-processes-2/1.0
 use_problem_json_content_type_for_exception=true
@@ -142,13 +125,7 @@ rel=service-doc
 type=text/html
 
 [api.html]
-{{- if .Values.ingress.enabled }}
-{{- with (first .Values.ingress.hosts) }}
-href=https://{{ .host }}/swagger-ui/oapip/
-{{- end }}
-{{- else }}
-href=http://localhost:8080/swagger-ui/oapip/
-{{- end }}
+href={{ $hosturl }}/swagger-ui/oapip/
 
 
 [api]

--- a/zoo-project-dru/files/zoo-project/swagger-initializer.js
+++ b/zoo-project-dru/files/zoo-project/swagger-initializer.js
@@ -1,15 +1,10 @@
+{{- $hosturl := include "zoo-project-dru.hosturl" . -}}
 window.onload = function() {
     //<editor-fold desc="Changeable Configuration Block">
   
     // the following lines will be replaced by docker/configurator, when it runs in a docker-container
     window.ui = SwaggerUIBundle({
-      {{- if .Values.ingress.enabled }}
-      {{- with (first .Values.ingress.hosts) }}
-      url: "https://{{ .host }}/ogc-api/api",
-      {{- end }}
-      {{- else }}
-      url: "http://localhost:8080/ogc-api/api",
-      {{- end }}
+      url: "{{ $hosturl }}/ogc-api/api",
       dom_id: '#swagger-ui',
       deepLinking: true,
       presets: [

--- a/zoo-project-dru/templates/_helpers.tpl
+++ b/zoo-project-dru/templates/_helpers.tpl
@@ -67,3 +67,25 @@ Create the name of the service account to use
 {{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "zoo-project-dru.hosturl" -}}
+{{- if .Values.ingress.hosturl }}
+  {{- .Values.ingress.hosturl }}
+{{- else }}
+  {{- if .Values.ingress.enabled }}
+    {{- with (first .Values.ingress.hosts) }}
+    {{- printf "https://%s" .host }}
+    {{- end }}
+  {{- else }}
+    {{- "http://localhost:8080" }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "zoo-project-dru.hosturlws" -}}
+{{- $hosturl := include "zoo-project-dru.hosturl" . }}
+{{- $hosturlParsed := urlParse $hosturl }}
+{{- $scheme := index $hosturlParsed "scheme" }}
+{{- $scheme := replace "http" "ws" $scheme }}
+{{- $host := index $hosturlParsed "host" }}
+{{- printf "%s://%s:8888" $scheme $host }}
+{{- end }}

--- a/zoo-project-dru/templates/cm-zoo-project-config.yaml
+++ b/zoo-project-dru/templates/cm-zoo-project-config.yaml
@@ -3,4 +3,11 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-zoo-project-config
 data:
-{{ (tpl (.Files.Glob "files/zoo-project/*").AsConfig . ) | indent 4 }}
+{{- $globPattern := "files/zoo-project/*" }}
+{{- $values := .Values }}
+{{- $files := .Files }}
+{{- range $path, $_ := $files.Glob $globPattern }}
+  {{- $filename := $path | base }}
+  {{ $filename }}: |-
+    {{- (tpl (toString ($files.Get $path)) $) | nindent 4 }}
+{{- end }}

--- a/zoo-project-dru/values.yaml
+++ b/zoo-project-dru/values.yaml
@@ -39,6 +39,14 @@ service:
 
 ingress:
   enabled: false
+  # `hosturl` provides the opportunuity to specify the service URL when ingress is provided
+  # external to this helm chart. If ingress is enabled then the service URL can be taken
+  # from `ingress.hosts.host[0]`.
+  # Thus, the value of the service URL is deduced in the following order of priority...
+  #   * `ingress.hosturl`
+  #   * `ingress.hosts.host[0]` if `ingress.enabled: true`
+  #   * `http://localhost:8080` if all else fails
+  # hosturl: https://myzoo.example.com
   className: ""
   annotations: {}
   # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
This solves the problem of how to provide the URL of the ZOO service in the case that the ingress is provided externally - i.e. `ingress.enabled: false` with the ingress not being provided by the helm chart, but instead by other means within the deployment. For example, in the case that a custom IAM approach is externally configured on the request path to the ZOO service.

Before this fix, the current behaviour is that the service URL is deduced from `ingress.hosts.host[0]` if ingress is configured in the helm chart - otherwise it is set as `http://localhost:8080`.

This fix introduces helm tpl helper functions `zoo-project-dru.hosturl` (HTTP) and `zoo-project-dru.hosturlws` (Web Sockets) to deduce the service URL in the following order of priority...
* `ingress.hosturl`
* `ingress.hosts.host[0]` if `ingress.enabled: true`
* `http://localhost:8080` if all else fails